### PR TITLE
Implement kernel panic

### DIFF
--- a/os/src/kernel.rs
+++ b/os/src/kernel.rs
@@ -1,10 +1,11 @@
 #![no_std]
 #![no_main]
 #![feature(naked_functions)]
+#![feature(panic_info_message)]
 
-use common::{print, Argument};
+use common::{print, println, Argument};
 
-use core::{arch::asm, panic::PanicInfo};
+use core::{arch::asm, fmt, panic::PanicInfo, ptr};
 
 extern "C" {
     static mut __bss: u32;
@@ -14,7 +15,12 @@ extern "C" {
 
 #[no_mangle]
 fn kernel_main() {
-    print("\n\nHello %s\n", &[Argument::new_string("World!")]);
+    unsafe {
+        let bss = ptr::addr_of_mut!(__bss);
+        let bss_end = ptr::addr_of!(__bss_end);
+        ptr::write_bytes(bss, 0, bss_end as usize - bss as usize);
+    }
+    println("\n\nHello %s", &[Argument::new_string("World!")]);
     print(
         "1 + 2 = %d, %x\n",
         &[
@@ -22,6 +28,8 @@ fn kernel_main() {
             Argument::new_hexadecimal(0x1234abcd),
         ],
     );
+
+    panic!("booted!");
 
     loop {
         unsafe {
@@ -45,8 +53,44 @@ extern "C" fn boot() {
 }
 
 #[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
+fn panic(info: &PanicInfo) -> ! {
+    print_panic_info(info);
     loop {}
+}
+
+fn print_panic_info(info: &PanicInfo) {
+    if let Some(location) = info.location() {
+        print(
+            "PANIC!: Panic occurred in file %s at line %s",
+            &[
+                Argument::new_string(location.file()),
+                Argument::new_decimal(location.line() as i32),
+            ],
+        );
+    } else {
+        print(
+            "PANIC!: Panic occurred but can't get infomation of the location",
+            &[],
+        );
+    }
+
+    if let Some(message) = info.message() {
+        let mut putchar_writer = PutcharWriter;
+        print(": ", &[]);
+        let _ = fmt::write(&mut putchar_writer, *message);
+        println("", &[]);
+    }
+}
+
+struct PutcharWriter;
+
+impl fmt::Write for PutcharWriter {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        for c in s.chars() {
+            putchar(c);
+        }
+        Ok(())
+    }
 }
 
 mod sbi;


### PR DESCRIPTION
Implement print_panic_info and PutcharWriter for printing some types that implemented fmt::Write trait.
#5 