### PR TITLE
fix: Fix implementaion of printing PanicInfo due to rust update

### DIFF
--- a/os/src/kernel.rs
+++ b/os/src/kernel.rs
@@ -74,22 +74,8 @@ fn print_panic_info(info: &PanicInfo) {
         );
     }
 
-    if let Some(message) = info.message() {
-        let mut putchar_writer = PutcharWriter;
-        print(": ", &[]);
-        let _ = fmt::write(&mut putchar_writer, *message);
-        println("", &[]);
-    }
-}
-
-struct PutcharWriter;
-
-impl fmt::Write for PutcharWriter {
-    fn write_str(&mut self, s: &str) -> fmt::Result {
-        for c in s.chars() {
-            putchar(c);
-        }
-        Ok(())
+    if let Some(message) = info.message().as_str() {
+        println(": %s", &[Argument::new_string(message)]);
     }
 }
 


### PR DESCRIPTION
The PanicInfo in Rust version 1.79.0, cnversion message to string became stable. So I integrated pringting member variables to print_panic_info.
#16 